### PR TITLE
Assume empty request body for DELETE/HEAD requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ poetry run pre-commit install
 ## Release History
 
 * Next Version
+    * Assume empty content when signing a HEAD or DELETE request
+      just as we do when signing a GET request. Thanks @alvassin!
     * Fix bug where `sign_with_headers` did not include valueless
       query arguments in the signing process (f.e. `?acl`).
 * 1.0.0

--- a/aws_request_signer/__init__.py
+++ b/aws_request_signer/__init__.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 __all__ = ["AwsRequestSigner", "UNSIGNED_PAYLOAD"]
 
+METHODS_WITHOUT_BODY = {"DELETE", "HEAD", "GET"}
 UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD"
 
 CredentialScope = Tuple[str, str, str, str]
@@ -179,7 +180,7 @@ class AwsRequestSigner:
             headers = {}
 
         if content_hash is None:
-            if method == "GET":
+            if method in METHODS_WITHOUT_BODY:
                 content_hash = hashlib.sha256(b"").hexdigest()
             else:
                 raise ValueError(


### PR DESCRIPTION
Closes #2, #3.