### PR TITLE
Add support for STS Token

### DIFF
--- a/aws_request_signer/__init__.py
+++ b/aws_request_signer/__init__.py
@@ -18,7 +18,7 @@ class AwsRequestSigner:
     algorithm = "AWS4-HMAC-SHA256"
 
     def __init__(
-        self, region: str, access_key_id: str, secret_access_key: str, service: str
+        self, region: str, access_key_id: str, secret_access_key: str, service: str, session_token: Optional[str] = None
     ) -> None:
         """
         Create a new instance of the AwsRequestSigner.
@@ -39,6 +39,7 @@ class AwsRequestSigner:
         self.access_key_id = access_key_id
         self.secret_access_key = secret_access_key
         self.service = service
+        self.session_token = session_token
 
     def _get_credential_scope(self, timestamp: str) -> CredentialScope:
         """
@@ -190,6 +191,9 @@ class AwsRequestSigner:
         timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
 
         extra_headers = {"x-amz-content-sha256": content_hash, "x-amz-date": timestamp}
+
+        if self.session_token:
+            extra_headers["x-amz-security-token"] = self.session_token
 
         canonical_headers = self._get_canonical_headers(
             parsed_url.netloc, {**headers, **extra_headers}

--- a/aws_request_signer/requests.py
+++ b/aws_request_signer/requests.py
@@ -1,4 +1,5 @@
 import hashlib
+from typing import Optional
 
 import requests.auth
 
@@ -9,7 +10,7 @@ __all__ = ["AwsAuth"]
 
 class AwsAuth(requests.auth.AuthBase):
     def __init__(
-        self, region: str, access_key_id: str, secret_access_key: str, service: str
+        self, region: str, access_key_id: str, secret_access_key: str, service: str, session_token: Optional[str] = None
     ) -> None:
         """
         Intialize the authentication helper for requests. Use this with the
@@ -20,9 +21,10 @@ class AwsAuth(requests.auth.AuthBase):
         :param access_key_id: The AWS access key id to use for authentication.
         :param secret_access_key: The AWS secret access key to use for authentication.
         :param service: The service to connect to (f.e. `'s3'`).
+        :param session_token: Session token assigned when using STS (optional).
         """
         self.request_signer = AwsRequestSigner(
-            region, access_key_id, secret_access_key, service
+            region, access_key_id, secret_access_key, service, session_token
         )
 
     def __call__(self, request: requests.PreparedRequest) -> requests.PreparedRequest:


### PR DESCRIPTION
Add support for optional `session_token` kwarg.

This is required when using Amazon's STS credentials. (#1)

AWS docs reference:
* [Create a signed AWS API Request](https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html#add-signature-to-request)
* [AWS STS Common Parameters](https://docs.aws.amazon.com/STS/latest/APIReference/CommonParameters.html)