### PR TITLE
Fixed presign_url for GETs where content_hash should equal "UNSIGNED-PAYLOAD"

### DIFF
--- a/aws_request_signer/__init__.py
+++ b/aws_request_signer/__init__.py
@@ -265,7 +265,7 @@ class AwsRequestSigner:
 
         if content_hash is None:
             if method == "GET":
-                content_hash = hashlib.sha256(b"").hexdigest()
+                content_hash = "UNSIGNED-PAYLOAD"
             else:
                 raise ValueError(
                     "content_hash must be specified for {} request".format(method)


### PR DESCRIPTION
Hey, thanks for your work!

I ran into "SignatureDoesNotMatch" error when I tried to make presigned URLs for s3 GETs. I found that `content_hash` needs to be `UNSIGNED-PAYLOAD` (see 1) rather than the hash of an empty string (as is suggested by 2) fixes the problem.

References:
1. https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
2. https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html