### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware alternative

### DIFF
--- a/aws_request_signer/__init__.py
+++ b/aws_request_signer/__init__.py
@@ -193,7 +193,7 @@ class AwsRequestSigner:
                     "content_hash must be specified for {} request".format(method)
                 )
 
-        timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
         extra_headers = {"x-amz-content-sha256": content_hash, "x-amz-date": timestamp}
 
@@ -271,7 +271,7 @@ class AwsRequestSigner:
                     "content_hash must be specified for {} request".format(method)
                 )
 
-        timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
         canonical_headers = self._get_canonical_headers(parsed_url.netloc, headers)
 
@@ -330,7 +330,7 @@ class AwsRequestSigner:
                 "POST policy should contain expiration and conditions keys"
             )
 
-        timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
         credential_scope = self._get_credential_scope(timestamp)
         credential = self._get_credential(credential_scope)


### PR DESCRIPTION
Fixes #14

Replaces all `datetime.datetime.utcnow()` calls with `datetime.datetime.now(datetime.timezone.utc)` to address the Python 3.12 deprecation warning.

The output format (`strftime`) remains identical, so behavior is unchanged.